### PR TITLE
Updated for compatability with the shadow DOM.

### DIFF
--- a/stylesheets/base.less
+++ b/stylesheets/base.less
@@ -1,17 +1,17 @@
 @import "syntax-variables";
 
-.scroll-view {
+:host .scroll-view, .editor .scroll-view {
   padding-left: 0;
 }
 
-.editor-colors {
+.editor, :host {
   background-color: @syntax-background-color;
   background-image: @noise;
   color: @syntax-text-color;
   text-shadow: @text-shadow;
 }
 
-.editor {
+.editor, :host {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
   Font-family: 'Courier Prime',Inconsolata, Monaco, Consolas, 'Courier New', Courier;
@@ -98,260 +98,261 @@
     background-color: @syntax-selection-color;
     background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAgAElEQVR4nIR9eUAN3f//yxhjjHFc13XlSlJJSPZdRbY2e6WUUqGilRYtUlqVSpsk0iqKihBFypY1+77v+748Huvvj/k803M/1+f7m7+69545533e23mvJ7T6RRj86/GW2rI/3xSy/3we4xKq+Ofvky216RP8V4L/ejJL0tX+/fln5VH+v8eEzVzCA0CnxW4kfnpvKmbNShkAvN2yl+q30YPfUTaZDDN4zv77HZ3c/eJamxsjGQCIjC5VS+pjRneUDCZtb40Q13n7xIassk+UA0D/fs4aSxTebObFOfKYgK9kWHqKLLPyJs+s+cimnTUjX865sPe+D2cB4JBJFps/rKsEAAILi8mJkdfUjmomcQM2+vCXQmyVcPPP8/3EavZ4sp/8n89k3CzW5Vwkt1onQf3EiMn8i3MWNAC0Zluo4CGAOskCwBLzQEnUx00sAIRdTlDGafTkBD0AqPguZ+SHNvCeB82ImckS2b/HLJpSLvV7so7xSt6k+Uhxl8zO2c+f3K1L/XvM2LuPKDl7mz823ENWcKuniNyVqw5IAOA2dYlsP/WAAoCDEfXsoXZzuC37GtUBYHd2NhmweLw0fI4OW6LhI27EPvszc/nYVPqfz2kB21gAaDJNolMutWEBoCJ4BgEA91hjXQC4ZXyKXzHcjNyOUWcAYH6+rvi+5b1q+ZnEmTIAMH/txv3zPfeRYQDAK28xAwB9vn2mASBykbM4xi+BJcv/+qKEvIDQ4TQATCi5TQFAR48MDgCCjkZyLZ+NpP89tqltS8ojs1Ccr3LTDHGf2wLmMI72h+X/Ho8JEU85ALiYfF4+vs84Mm4iK75cOkWbSS/z0m1wOMufmpVFzZxepgCAM35ZksbqIgoAVpkms9vCphIAWBTTW3O59nXpoA4CMqTqk3gAKMhZI0qT/EM8AYAFVueUCPvvRzEqjwMAs6qNCgBgXj4Rx5KprekerReKXCzbEqwYPaNM8s/n+HZzGYftXbh98zszADBp/2geAKymmxAAuGpSy/XtVqyENACIPDlM3PdR8yf8ElZfRNxUvRD2a7Ajqx1Tz2QmLxW1R9FYZ8bn1zQWAKYEhEnumZaztjZ+EgB48HIo3fKTFx0XNElpn2c6jaEB4P7OGLmJIo7+6rCAwv5rWWoA8O1DMG1SPUdNy2u97JpJvopaOlTeyF+Yu0nemBooUrF6xDYFAKiXDJBcz+xLdxvWVlxwwepT3LCbC2gAeLb0AwsAHfZ+ZLrvWCPOXThoCw0A7RuiCQBMcIvR1Kp9SgHAWnN1NjNgNLXD5rCseF0+t3FwEAGAds+y+HU/BvIvqzdJC8IclKT4n+ejzXWRSCYJRyW9b3+nB208SD0cHi8HgNHGFTwAyKRf+XUuBdL2rtnEtu89KQB4fC+RA8Axv+4i45htjKAAoMX2KgYAKiLLGACQbnXkAeDopl4iHPsKRvI/bnpzAJBUzXAAoHfFgwDAt/obzLYrQ7mbdrf5cyvS+CVf9Oh+bjTPt35CdZxN+MIzLgLhW/frRMmz37IAkBTJixwza8crWVNnGyUO8jBzZN4O7Ege2S+VAcDAiQ85ABg5wpYHgNrqOna+xnYR6d/fEgIAFavXUwAQYqFOAUBD8kBxjO+tl3Tl22MscbzFAkCvuvlKnERfKeYBQDIhmAGATh33UAtb7ecuJPTm/j3OZoAxBwBzc18zAFDesQ0FAMmp9kSv4DC7946ryEybHn9mQuc2SLyDzJWI6rxtv9Kc3/UP0d5uEQIhz/ZXB4An2T84g0e/eABIG7pdBgDDNnclwXPtVaRtnW6G4t+fq+7G87odV4j7u/73Y+LddxZ78VYqWT3RisGGzEzpv18o3DmJTz+RJZ2dcUfpQOv8eRAPAPKQTjQAhKTu1LzqdZ6bXrSPnzlfOOirb1M0AMz+GE7HfRS4vmU298eDEQDc7vxm8k8spdL97JnsqfP4/DnpcgCYRV8Rz5/ufY9Rzl4KBgCuGphwzz69YXaVJ0gBoLjrWNossFZEqGFZNwIAnTrvFdd82eoDt/L4Lib683Wm26aOtMSqMwcAq+lPHADsuuZCZ5wexxsOc5AMl43kok/eZT9MMKP2tZjNd6w2Yc8PPUf43T2JU592FADkp6fo/TO3r0us0t682syjPAL06Hfb2vHnnd6xk+c2ydunb+AA4FjNaxoAzDxdCABMbjGLnzeMkxh16S8S0fXxDw5jxt6hrH+8Z9adiGYB4GvlBkGNrGvBde1YSxwCLqro933TmxjTig08APQu30r/7a1F5RuN4QCgU8Q6pmp+Byo33Iu+xU2lAGDX1PVSABgd3VuUihUHfpD60Gs8AHxJPCLpri6hXP8yZZ3G61B3YpbzUU5J4rqVDUOYug07ZMm+s8T3Zx3cQdctOSN5c2cfDQBLV5+lAMDiYAoDAIYbHjITM2y52IGHxXdM5w+kAKBk1EolKQCAhyb+5LBTk4pV9O9H894ARn22MeN8OY4FgGnpBuI8bkMS1f97/DmNZivtQUAYKT2kLnt2cqjSGnb7atQKtq6S7vT7ITAhcRtLAcD5+osiV5ItCyU14fZcXWoJBwAOdbv40L1Zmv/8fiXTXG3f9Le08fwgtaJvFQQA/v52nXVMT+MBoL/MiwDAjLwDFADo+p5jAcDywRwCAKevVVMAcLW7Oq+/2YyfPns12z3Ei88rukC/+qYsmVuqz5H4chNpydDFUufEVHL1kD0X/yFF5KqP67+JcE/ab8oBgIfr4WYrzekr65GzQj1gwWol1eR3qYwHAMOVf5GZcobxrLqstC5zuw0T4RGj5jVQsLJ6+JtJR+YeleeX26kQ03N6HAcAIaNz5L57dclMl7fs22M7RBjXffBhwz6U0p6LR4jayMcmTnF4YgptPLZSZDzFWAMao5ckMSN91alOJrb0WYssCgDej35KvTWqJpmG0+jr08bQUfajVNROt9ftaLP1zuLB93TWKc5zmQMzMHY2DwA2hzOYQcsT+UorAUkrQ5NUDAUA0BltRjLvm9ESv+U8AITmCf7G6z0F1DtbCW0cu5s63b5RBHrg5ygiO2jGR8UJh3yHSH1x4yOObeJKvrdWQlj/olMMALRousQCgFeCcKBHBU9X4tRob2saAM5NbVRBeIyfseS15yb6V//d1DHLAAkA8MYjGACY+WKC5L/H/+mpttejAGBunJnOqyFrON0px7g+Gl34a0feEAAoXd+WOmM+joN5lgMJXGGt+8+L9R2EA3Gm1lB+c9Z32jbQVkT6uU3FIrBPzucxc9YMVLKbi+q/M8HmT3hTzpH16DmMBoBVi86JhPiy6yoXtahaBgAb66xp91XHGQB4aHyV+/joIDvvyWklwv9tIRWI6+Ih+9mR4QFgwagg2a6LZ7myTCslJ7L1VivJ1sgcUm28gP8VMZfK2LFRlmMpWIudP3NKh+1EA03ewD5XdmIOxQNA+wFLyURKn/pWTfFUpa847+13DjQAuLQ+JznesIMKLA8U9zLBZYmyz/Cfp0WaOg8Ajf0z1V483skAABVVwfaacZw0JYYrMcGujMlS14eL+VqjfHbnNh95u2MaNGLs0+XJe3iSaDhRaYPqb0YonR07O76nDm52kQPArex0UfyHa31m1p04xReF5XIAUBJxVwEAGZ+clZCQW/iWuF3oInJT+ZOupM7OXyRwp1W2Spz5NayBnXDPk8y+eJf92Taeu1m8l13y+yMBgBb+grdr+qMHdX7/X0pwFl/7TvIClklave9Bfa7fygCA25CbKsi74VQvA4DpzxTUj4WtVKRiUIMZOXikjs2t3kzP2WEhIpIZ2ECVh7urAYDr7XgWAALm50gjzvSmfJeMJB1+SijToq388if9CADccL/8P30sAHjL/aKs+kQoW2eexSHSLLcAaaLbCjkAaHjkk4Wxk0nOqlKda7faMwCgYegsBYANPeXcBSNfHgCcnLZQp2Wa5Ht1PeMpu85E3L3FzjsXJnPed4Nj+6QqLdJ7yiCRuy5PUadi7tySAoDNqxdKyLjvO1X8fKOnCWN0erpgEMzpwAPAhN1VkoXtFEqS5HHpLgUAtZgvEtx/QQpjf2soNzxgNQ8A213nkfY6dazN/IvM28ZTzVGE1Q/54yvO8+qPZrDjWi2hd5lP0PjntxMeMtY8ZoEcAD5U9BP3c+1HMQUApgbNhNy9uYrbaVgonhEjZpezAPDTY6P43nKdKX9U2wCw/YsDV7sprJlxMi4Q+XOrQeyEtybiBBrFX9hfJlWU7oI8ceH08DFMw8pF/1Nv+nW4zwJAKHWKVLskkKu2yeSxqTkBgIWex5Wk8IutqQpnAsDMeHVdAIi0vKIOAHUd9ooc6rXYWsOnbtGAoSE2mgCw0MVIxTm0Pb2MB4CeNtMpo+VavH++Lp/7eYiIjKrsuXzQkxzpK3dXvq1RAg8AHcrnk3H20yT+4x+KxJ5eEM0AwLusxdTwkDlMw/x8JXgjPhXR4du96B82T3hPLyFM8yNprygRdlZ3eQCIn1IiWbppO39UfycPAI5JByUA8D1MnwWA6K1azYTaNlqbAYBBS/f/kXpNmRrMpLcm1LMe+1jqh5NIrOe7DcTxGybE0NlZBWptt59h5EFHlOYxXDBPCgDb7qdyXjOuiBz0cvB7BgDYDRelSRlS8Z25eS5k5BgXdaPsdYIzuGWsontsP031bqxIzFXLCqgeDyKViBtX5ygHAOfdY0XiWTiG8sERbioEk7f6RL3+dEFck1MzYFIq9Nhuo37wALCqaSzjeUVwA2Z8s+AA4FPdDAYA/EY5s9fttZiCyYIlp7Zl/P/kegAobXonwmN9NZ4LSZ3MAAApPM9OXryIyly4XwIA44MuUyFpGgweaHbm5q5ewKR2X6QEeHhgCLc5Lp2kDHMVJ/wx4yMNAL2Tv/EA4HHkmMhNsTM2kgaPBzLtEX1FsVNozBI56sW9u1TZQYH7rDL8SXywLwMAdxrfUPn7KGbclGxR6pZtzpXVbDhDAcD2G26sQ8FlavTUq+xvxQwlfdx2a9n/dDrNpthr2vvPIwBQ6TSY7z5pF7UrIF/Fk940oZJTP2bOfTzTfIZdiZjPDr4gE9eaM0nC10wJF5mJxDQxBqkWIkP0ahQChib3jojfHVb0Ic5FlvyklKtCIDPkrhLs+ya05UuTpErEDCufI0NFmyn8zqn9xMFW4XHsjPo40d1f1foetaD4AnE/uo9tc78tsT+eISIheKihzhGrDypIeSwXTFh006YurT5CAUBUSQsKiWl/VFF/eq5fMiZNZ9SUEFi4RwjWPftcpuLAJQ4U1Eu+dREBgE2RyQwABN86Ks6xw7JeOLeW+yu6zNwkIsMrJp95pLmcAoAvKYOYh31q1YfeXkkAgC/KVTIITju4s9qXDsgAYBo7lF8d8kBJUumcMm5H8V2t+ZZ5IoxXFltRADDBYj+VFEvoybYDSE1QVLNTmXGOAwAv/TAaU7f05fST5ylRz0aerIK4+8vU6U5BZ7neXUNURDS8ylXpuym9NdnUunIGABb8EvTkxSe6dJ/9Z6QAoDunhhsuNaIBICKgq/S/5+uxdqC4/oCLC0Sz22r1ExoA2rnXME6LP7LuF8dQFabjmOeHO1EA8GbERhE5rW/NE2FqOJotfr9g3CgOAArjJ7PfEwaoSMx/P5PzHZkPNQYUAGxs8V1kvvB0KDHi4EkX5ADQK3WeKOn3Z63iAaBM5wMFAL3JD6pg9lgVj/7GOCNVRu0xY5YSUahtu7gTqy3JmOSF/IY1fdUAIGDbFd56YRgPAPl+jIpkzMkMlRTPdWOW+ID/O+sxe+3WW6UxPjNusKP2B/PrlhrS0yqzeABIDW7iYhqucy9fR9EA4NZBCCGMflfNA0DJ6BVKHBphkSMzeicEKB8mLZACwLKzS+hnceYq5mXlsFh6ylIPesB5Ny7DTAj119zneTzvy27YF6h48j2RBgAb8zIpAATFlTFnBwtOqNv8ZmeY/rZZiDjU9ZFI81dIAeBEQSoBgIa/4jm5tbuI0DO25aJkPNEuIW18gjgAWBicztd4GPVx9+jJA0D67SS+hM2VAsCKqHTZqS3/CWqOyHVQAECTnrG4oZozUYp2YWokMsF8EABMufpYSQIi5bPYkanx9F89s9hre7wonSujuO6v9LnaW1fo6cFLNJma5UyPiFZ02HAD4jnwk8idCX9vJV2PPqdG++arn7HcRAFAfc0U0n+TmpIKqkqW0QBgWXBFLey5lyLApTki4N9CQETMCQn/7UMIZ/akBQcAE+5Y0ntOXVBSH/9+nObH8snen7mevtk0mdDs/LXpZ85fHm/I5a+Kox5Wb6MAYL+3Mbl3tEamv+Ys/ytICCBGJndSmvvDx9HctIOPpQDwZXH7/zMGVnYkvNnZfH2OAYDsDbsk3p26858+7qTX21yWAoDO2sECnr3/sifpw27/0ZSNu7lSMfBYTyWRyol3FT9/2TiX9dmcKusb/IuJuNRNJGp1ZGt67e6d0jGdHrM2nZ6oAPwwLYtf8libc28noUzTH7PjLgiBQ6uVJVIACL/mJEpG/SNXUuTxmIx62EQmv/NTc7mez2r0NhDVTfXznvx5+TICAKnBgnfeV1vCAMB6/b50fcwI4vB3R+briDqyJ+8mGRtpoy49qin4LmkrRL/Da58PGW0mZApfnHzCAMDx0ko28/svpf0f16vk344bTVbkx6qVLN8mN3wQzc3etYIDgDC75Tq5m805ADB36Cnu+8R7cxG/GfIt1OytgoFjN1lwqLtljdQBABTMsuIAYM4qN/mpMYvJosN96Yaup9hzM1cQx9xNouWVNNRb/W+9RSwA9P+5pDlkvKs5PZrsUkgas2+QwNOB6luTJxDvHaXib21Sv7AemVFKhNnz8ry4UevOGhwAbP09TiTq3vMVfET5S959bKFmwPQIKQDkVfv+UQpcT2jzjMxe6berK2cN+vfneepPudNsI+nsk88AgM8KwSndvHmN4vLNnxwA6D4ok8xN2KSUw/jnaXKeq1gbOE8rkLoomLxjtLi2ixsZAHifrk8A4PjXEN49Z4haqyVb+KjHPLMy+h4FAEMfVNL3je+xa7asI04Go9T+NL/SI80iFADc62jGAMDho104x5gCFgA4vxj247Q9RH24oIfzThVIAMDsx3seALyebRVV2ojDqzjtu61ZHZNlLABkLE9gAaA8xEPpPPm99j3R3jFJJNBuh3ny/btHqAHA5YdOIlG69O/FD/3Qn7o0po6vJwwFAIbHL7MAEBy6UwEARV+6MZXGEdzy6FRxo6c3hUj8E61EKdO9+5gKW1PHAUDs0HhBbSQ2W0KVfiMVOZ46IoNE7pWSWfNMhcBk/1VswBIh/93ZeY4EACJLu8kA4Ka3NQsAs1ttpoJuf+I+z04TmaJfZqICAI5ptCSmGkPZfY2WvPrdqURrjAX1OLxJXKvjjvVE4thV2HPdmEh9A5PexClnoQrnjeByRA4PzdrCPL9zjRQtmqgPAKcc26uouG8uGzhPUz0y9n6//2neFh0V4jZP2mjx2rHeBgBwn4ySAsD6UC/mhdptGgD2Ppwr7+xbLOsewJDi5buZTXtGsEVO4/mHQ25R0ZpHyPVWrQXOW+xEBZ/qRHpYUKRHxkPeIsFfc4izUOHS9H0rBQCDLy/lN9+4qnQOjpnynovYM0MLAGykvrRO3yxZ8MYr5N2TRBYAZLV6fOuZJ9jtx68L6kfqLNthM1MBAHd219BusyapqOH++waK3y26uOyPOAgKMxaZxuuUHd+Q/5HNadVc+IC9U/NIp8+N3OmvJ1QQPLfYhdguaMMDABvszQKAgV+V2qJCFzbJw0Tuoh9O1SwQ7PmtLol9AGDPJAOqYaQ7AwAnv8pYAAivrpK3Lz9BlRv3VgBAmkUh6fliL/ei7zeVTTUavCdRg+5SS3Z15AGgbYIGiaw7R5V/fcVV7ExiAGDiMyFgt7i7p2RjjyQaAJ7jM5ll/FHJjN1oNuOP6i1O76GKqf3U0oBWa7hJ+afOY78dcGCe6J8SCTjJOkD8281dqNApt85jAaDH31eYTl/XMQDw/HSezNXvJAcA9zdl0ACQcciHnNZ+yAY8Wk3eP+7I755uJHk7b6oMAHyOrRK1RtSH9uynbhyLRnm0esxGc5LrG0IbL5vEa+nUEwBYFjCbAIDW5ZbU2/GL+SJvJw4A7lU2EQD4FFQoIvP+pkwCAEn7Eqljv8z5DYXN+fJqrQNyANCb/ZPf9/Bv+vJjITCpmBzJaN35KiR2fE5Q7PKXzPhTQgInL1vzj9wl6ycjcxPOib+lOaeyAODTfxA38dxiBQD0eeHCndtynB6Y4i7Jrq0iAGBQZSOqwDCXOiVJKfteQU0xuSXzL2jLA8D8vsUSAPAu2yUN8k3pc4yfRACAm7idS94WLgGAsSMnKgCg5TUnca51TmdklnGRfOEPXlzLJWCKyOR6h8ZRLnm7hRhWbXsVl2HFiy3N32UvW8jP85nMA8DEjYcpAPhp8ZDfckgmODZfQxi39JcsAES+2MwAQCvnAeLCCcPWigvf2f9dacO3C4Vzp29gLDfTc5fajZltuYdLd7Lne/UhHuaXSPZSZyXkF++7z1bOCyJe+4ZKl7W+TAAg50wXAgDjfAOV5rZxiiIAkO9/nRqVv/D/6+T96SmWvqR700OohaHPRDjK93bif85dz2adT9XtEj+UzN1DM8bFZVoAYBxgwgCAt2Gk4IckvmYB4PC6JsXcBQNEI2hgUiIPAK7d40QprW9ZLsK42MBTyW+6P2SjsP7V/kJdk9r9Atb2SS0XY5ApNy5+orZ/l6mKo3Vz0kYuKKRYd9RJc7pk4VPhQC8rJw2/P9Jjs3sQAAjtV0mSDl9jAWB73FTa75cbv7fbcWr4VS0l9bFwtRAb6uLnzrax60ABgHP3HRQAnH1DVFSZQ7d07ntILwoAQi+oMQBwaruOikqKbFNMFy98xQxsq0eeD/rMnEk7yweXq/0nBteG7nF0mEjUiaeUC9kmdHaRsNuHivuenjpAHQBa2U/nZs1MVFprrq+XkqXkdtyH9Qufr1bl+4wGAKebzeromgahNSK6qcDabeNxqWaco/JR0TCNouXHzcju2E3s7vdFbItpQtlPoH2CmEUkQ8+yH6enUAAQ+HwOKborlEjmeydp/Hsup8s2IiKnpK5hHg4cwmzRTCT+5gfFTT6//JNxfNcc4rbzNiW2fX4yADDbtYkzfh0kAv5og+A1D670kx3t6sHeCjZXj3HQYjav89ICAG3/ntKh3t+5lJnr1QHAY99DdkmWDwsA40PnkHZn0ggAZI76SQHAy9rFTOq7N+L8fo5LVMzPOGtjEuLuKLnk3IsHgHftq8hgryzOycydN+xYIunzSoO6fuQbDQBLLnXjACBeb7m4n7TqNaR27QU1AHDwC5YCgJeRrrjmor4R9KJMffavXqUMANzoMEX1nBtxvIH70uENBQCL7E0kVNYj6uyYeKWDz+dtKX1pqi3d3SZKUrxeyBjqB6xg7iyNkdld2SfEasZpEZXJAQy48kaJE50tn7IAoPD/yviMmalywMrajSEA4O86ndWuW01XRf9N38zrxF/VW864675iB9i7c4131wuO5PBVEgAIdZPy0FQ+xE/Fp8kA4EU7Gb/8hIkSDPJn5gwAJETbCfVlTev5y/cy2dL5m1X20PbsRCFEnpBFAMBsxH3+kE40e7HHaJEQ6bm2vOsMC9ma2OvUwfoI7kZAcyQ6oipSNm+vhRJsk88LkhG7yZx9d+cmmb3SV2Dah8Z3qR0NvZmWTpeYhccGs6EWjuSMhpHcPZSwAPCu60lKx+m1EpDb7tpRVhOEwmgPh2VajmME83H60/lMQrqVDgAE5rznAIBIVKPBFbXjpRGbJ8gB4PPDVgQAjsb4sdO7gwremKA7XKOSv9WQw7x7JuMAIGdnggQAtCvasZ8dtzH5fkJJqDHdkwlLTZT9FcxzAOAaMFTFGHh6NYVT/D4iwrBnTKrom9RsVo7fBcQ+JtcWvRGlvHVaNr0quYm6f+6AdP2R9ZqzxnoxGS6aLPfEmG2YOZ7ZX13wP9OzDxa5Uk1fz4lMUHfzsRoAFNvOV2/YtEbeqdSdCr8iFBv6DntE2C79hbmsO+6RAkCPa6lKSPd/FCADAO0LQgpycdEoEVA2QLC03O4cEpJbgcOUuO9XZg61r2s7pndjncj9b2we0ACwYO5pfslabzUAqB/+UBaytiU1s85KCgDrFg9iAKBLe6HasWttE2c8/zi14+lyGgA2v6hTkaaOg9aTXtKb7Jm1z7mwJ5dEBG0NWi/C2z/lb3Zk5TrGpPcMXndMLTv32X5CbidzbY+GSEPzu9H3k/Lpss0L5QCg9UFw7Hb87i2+P6HKV1w3IkmosG9Xps3Ero9SydX7748SJWHno5fie5v2CeH8pqMD5Bb7jZjJ045IAcBxWH9SNfE4d6L+WjNxy7ROUi8aBRGbPKstCwCxa5LJ5AJLNYXvJybVo4kGgA27JfyrCBk/+VwBczJFjfXMnC2xO2LIPNvbnCOp+JnK975SLX6e9KWvyLU1k0t4APgeJaf9PxVJp/VYyD9uEPIYvtW7ZUOyzilej5WL7zb1Oc3lJGySxx2cqCJlWU6atM+2IMq0uJjx3vCdv6UbLwOAFUWz1AFAo1I5PL60Sw8qwD1TCBN16STUm2UuZe/f+s4X/nhFA0DHRBk9811zS0TofmM6Lv4TNS3NkRju9VGLjx3MtZnmr7Cs3CKOebC/P5n4/AffcoJQJHLHolbc723PDqSfSwX3pChIkI4b89iZkXP/Z4bxTMRqYd65Je34aUHHleI3C0wXiC/Gmmtzid7jpMVPbhG/N7ky7+i25P3AOME6i/Fg946aoA4AWl9G8I4TJiotWL3BVIWrGbvHItB6jTyru/E22e7qKiuRCgV146PcJAAQnhrG7bzUSzqzpQflqFvFbzEtoZa7yJi/xrhxMYnNUh/0lX8AACAASURBVNmo2Ye8GnmbbaOYwx93K6Fmmx+We7UW2hYeDNNRUiu6nTvxA90NOQCYaXeFtfKKkuSsG6mec9+I22AeJ9WPWSb1WnNQxco7Ni6FqtX/xo270oYLN24i9d5X2I5tcplwhxyl/R6ofsXNLa/4Y4nQP0/EwXtcXYi/mBcxmLOMMHvbELuo61J428RTABB5UEjVfh7fiSrZkER9/zSGqjdoLgwIP/JexZNnlq9mN+8pVwOAMusA+l56kvwMw5B1LaMpJ/M8FU4wCreWF6UkygBAXtd8IJqa+PC65/REJFQknpBtMQnliidWSSqOVqsgp/uJbeJ3jcHn1QBAd/ZvAgDejCkb+KiWBgB7nWR5/35uBADmb/9Em3+7TnYHL+Yu3PjNPJq1WNpvXjuhyMBuEQMAZ6PdSKXzfSpz10FJlKO7pu7KUcRg9zQeADb5fuJDh8n4px16k6SpaXTXx37NFSeKsTQAkKIdKsz3z3MovlRk+OEt9WjT03rUgyNufI8rOaRXJ1ehiPz3fAbfB/2QENKBdXUYLZqA27iDTEGv5r6JcW3nqQNA260FPACY563lAUBrRxILAPVXekgA4Fbnn5RJ/FYFAGxuEcnr1q7hbs8PoYPjazjF5RSlc2ZGvwXNOfzxu+kf1k/FDW5a1I7arfOI2jnZg5eG8FLnN5XSkFOEXfdGKLsxuHlSDQDWnpwuO/t8ocTwxzEOAK4PmCnkMy560wDgr92XAEBYbJbGxyNDRCK63R3HAUDdnNM0AEQ/Ewqip2cJ8Sl9aUcq0rELcU7OkwOAcY2zzLxfGAcAG1ZFysyeCYZKgp9Q+OadX6DENJ/d9ahp9YeExqL++vSD5xyn15ajrb1LCQCsKH0hMmvvCV2Z0Q8XswDgaV/BQHJAMP/yzX8LwLxrorLGPhIAXvs3bRHhJWTQ8IiJinAQJ/LT9mBLW7YnGx0E1Val1ZcFgIT8biQ7e5psV0YXzjnfy+Cf8al2M+j9j1y57NzzZM6iXhoAsHJ4YnMw7q7QHLTzvS3j0ukFZdbvPF92LYpe/Sn9j5bMo+6WIixntSbIhn4xYfwHjCYRMcJZElgyngGAjdLvZNoDTfL45C/avO8mymtsSxJWuF3lTOo8PlYa6LVBFmNRo3YtzYICgOinFYybr6MSsteVXibD24/m56r5CFlEvwPiXD67QsgPg+Z07NnznZTe9Z0/g2xPzhHHD5t5jfp1UEhRRFYxypGGmHcVDAAcuD+Kzjt9TyUM0c/Mipdm2JIQ35HMgMBMpuuoCzwATMrZwoXuN5aZHzdhl+70UFEvhVNzZADQNmUnb+IWT3fzXkxP1P/NHT4kJG90Ow8h91PzVMzVShxScZgibg2R/zVLSP0+8RX68/auWkn2fSun7wdkSQCg8zMBmRsUwxkAODa6WbW8rbxL9tg2+0qNwS7i3+9ig2gACIWH0t6N9LuSEo8p/Kqh7bj8iDZ/zAxmnrvFJLypJb7OX7mtad3F9Rp7r+MOupuIayTv3Sk7faxCVGuHtKJ5ABj6cxsBgJMZ1hQiYpcyADDdJJu0ckhhl9/5W8iUPbrKD10sZY49NBYpuuVBpaQmKJupu1jCAoB0Szu+m34r6lXfImqt6XfOYUqEDACODusqX9tCCEHMSRmtFmhvxEXlx0iYI8v5wDsDlTh+raK5z8/IKKFZbZnbKkcBGt7yG7RqmSuaTlzr9+biJvvfqmEAoDZVqDaJva3ObxhvofbggA6ZccGVsrq6hgWAiVcr6eDyVEojvoEAQN2p5rT0mKc3yYFgN9khi2qZw5n5KtIjy51El/ezkxw5OYcBgKltZrAVBUHc7z5C58DGzSck2SOEwKP6q0dsXEOcFAByrcax4xoPsgYNDlIAOFYVojR35QUh3NQlfBAHAOt7ufIYck0wc9NnCGGGuDYelPqsltzlUAN+eYirrE1YBQcA9Ie9QvG0/xJx0inP13MD9OpFBLNq7/lTTCpzeqEPG7p9JB+2qr3429XRv7mdCiH8cmRRnJKBwJ8cxHm3vKskJd6nbJk3rsbUkg27lDaxLG+QkrGwMqRMDgD3jram26KGN3JfJG2KaJI70n+LEnas7Va2xZckDgAOxaYzJ3fe4RfP1WUs9UaodX4sFHzH751BxplmNKvBjL3iIdyBt6f9Z30RpeP3AAlfr39EWvcd3MgmoXr9Uk4EEzXstIT3/8iMlNRwnrbO6gltt3FJ0/poAkAbYsUAwCiNn1xdyFTafb+eDACayruxtk2XeADY/GMij3VbpipteNciqVCxl3aAsVi9UO1ZykkV9bXTOUkGACW3urKbw2ao/F57dhm9dkp7JZVTmpwqa/MhnZPYNPIA0NX9G7+S7i+Zvn+B9JK0lAWAc0cbmSVzzvN95wrZtAk6ISrnx/TRgeK8OpN5au3tVCU10i1XT9xPUqJQXTn9Ecvouk8Rx1lNfy7U5pYuknR4zZMhbVowAFBaZcpuHTtWJIonM4Cy+jCYB4D9G3PpiKNFf+xpvOQbRq8/rGB6D49ge5iclK9tU6+i2qjBx9nxITmM9/GbzKCIjVIAqF/ejX8eU0EUhdMEZjdLVo1Y2+4M5q/75fGHS0YxdQ1OrN97QSJsDgkJmwKjcAIAOy4ESH+0baHEra93TWHXDREq2iOW9eauBpnyPmE5zKpBbnIA+EsyiFm05DQHAFbH1pPDeceIb7iv5h1e6FNsbdmV0jTtS1m8S+IB4GnrZLqmYKB6eGmG9K7E5X9WlADA2MmnlaTO7p07DwD+d2/zABDrbksDwM6COB4AXqp1ZQtudaG/2D+ndjsJ3bDjcybJZzu1p+1bgPrL8xb5vPsGHdMtQ/pkwksmbwZPpxrz/GmcogHApCJXbuKyjD4w0lVwGyomi8hctPUju25+R5ExJi7uw87M3cdr9cr5PwsF1d4I6QbUFn0RN3sq/xELAEHns7h+BsnsGociJS6tqjghPTssVap5WNjwrQ9eZPzub/zTRGvaao4n+XTmNAsAUU4b+hztFqYGAJ5rb0gA4Gf/DGpQooCQrfYXePU2dVQP85WUk/URdQBYsOIZbW6YIo19sVVSXfGCfJ1Ec6PWdVAi+sk9QjWKXzshnFI/T+h0XWUUrgYAm1oI5aLylk5El9biACDxUoaIiIWOwu+7D+T+8YAecKhIxIXt3n7U1sxQJUYIvO0t5EHcptAAMD3eX2We+f6xvGbFIO7UmARF/OZrcqvRr6luF4PpWVmCeVzYIFhaR6IjSFq9kJg6PuE/BlGIYaY4YdGurWoAMOGin9rh5JXN5THxDuybrT2Y+JNe6lMr+1IAsM7L+o9lQ+EvOiqXDBW+ZG9LWysBXTj2hIhkQ+capd8OZ6/kf688QnajlP209BxrcvFvounQjTw+HiCOG6ZpoSIt1l6GIkf2OFjNhFpfoQGg9InQEbyv/AIDAMunnuXqAnqwALDtVSNndC2LfxniJj3QZQSrd/yxDACcnkXwANC6V/Ocs/JztOjdymGPsMDj7MMdgqWUmjmIO786Sw4AMxe0pfOzbrO9fSdwV9dP4fv0sSYAoDdNjwDA68TpNAD4BaRRlxwFp/Lp0QusQ/g3gfmbioSDfb7WQ+4a4yZKxNk9A8l5jwtklMEj0qvzQKWzxsBuAtsrxJVemFUgmnG1yYJJef+xhQj4wXFP2LKHm9grY4dphLhXMNftgngAiC56wQLA0MOCt1zRKBQjJ/3mlCRywIEoZtWAWvZLrtBL6HuhWlQNx51vEQA4uM+AB4CC4Kc64U+bzWXLPW9FOJ7n/qAAYLRuJndkQhHnttaN+VuyjgCAjX2YRl3MR3qcaRsVlTLJp4sMAGwi3jLqnscYp73BytX9lWHM9xsL2ODjo7hThrrEJ0boykrVb66u127zkwDAe488elhQLyVG1itsThlY6expnrvlMUNW5+ArymPeSxEhDlUWRGPQeqE2944TAwAHtz5XMQv/djpD7Z/TXFc7oltr2nf5bFmfnLF0xs874ib3R+wT3+1sIJQbFX/dq3KQjex+jgeA4wUfuZplQrnl0Ba5FABkpAsWmn2UA1OqVsplr4jkAGBjRohoFZVZd6FORo7nAKDDhkK+h/VH1oauIanDLskT/LPZAReUdfkTPSsVQjTUpYj7sbso5HNeXrRmDcYvoViX8bz2YI6L3l3G/zpzgcxzHc5fCx0vzuH++wpV96SJAoAxufoiki+UmLDuY39yWWvDlEIsy71Gy19+jKY1Tu2n4OQpFDOnXd1DA4Adu5cP7jOQ/rxN6Cx9WDCGJNpF8Ys6CddL9KsuVFEXrtOaZNrbhUhliM5PHgDGTDCXA0Ct+mlm1htvrvxsukp2rmtLln+XJvSN39kyjQOAkweVOXD/vq5/9NR/P9xBjMwLqLrQERwA1OYvYwwMz5NvFnfZyHd9mdzr15WQPKO+ia9fPZ/Ijwzno1/G0gCw7mCqOgAM7/CeTg/ykAJAYOJjWb19P7bNSTchV75iJZ3zMPuPBkXbnfvoh2UF6gBQtXGqwEShAzjJrKtC5Pd+ByV17BOyRg4AL9YIvSZr+k8V99Zh1STJVvthapi6t55cHHxAPeOSOV1zajWdO1KfPHYXqsmtClermHkL50/SAgCv5Y76RyY1R0U7GXVljL5oi1HO1kWnlTg/NCyDGnQzjJTOuUMAwP77NXp31N9KAJNw4VaetGfPKdcuwqGbsMpQCgAWi+0lR3ZfkY1ngxgA0N9eJyL8TS64vk5CCVC+1WzS0PSBLlzwmHc/4KkFAEdjZnABZQZKXLm/Sz+R8Ce42UJz5qK3ZOzUEzwAWDfoU/l39LhfN06xOwuDGN5KKDGdafiZAMDEti3YIRtHU8eOzKGaNnuqd77ckrZ5v4jmnx3ip/n84recrlJM4RYzRqlS6qI3Lx/89QRRX29Cb+8oHN6bGoS2vMNahczePvUMACgOCnelYIHh2D8e0OP0S+g+/kYsAOyxG8TpLbpLhbi/oyd6JogcozmkKwsAK3YIcS7ZXFtxo3OORPENecL1Twl3XnAtrB2ptnVC30Zu8WhxzbGO08S/p3Fr2PatFRwAZJ8YJN2k68oaPPkoqrrbG6rUAKCw1F36+fcaCgCGt6wlh+4ILRS7x7mKTBS6opt0n9Zm/vTOQUx6YncZAHgPslaSwCeKU3yK2zbRgBl+sg1l+yJNnvchTiS4/Xsh/BJjN5F2P32RXhM4QwEAXzOWiGNcTN6Qtc4J/D0TjiHRxzkAqNRVl86dWSUyXdXCPcTfhmPXF6f9UepLYz2bGbRvl1riGxP9x4F6doLZGOgfqUhveYoDgNfLnvOtQmmyy6u5l6PHXxxTFvaKsinb0tz65m5KB5k1x2+mdOpNAcAzewcVc3Fi31lcnG2uCgxtDwnXUij6NBsck080l6auatebX5GzmDecuI0fPbqarj9pLsKU3Ws+N1uvUmrbrlJpvY27xkkA4GHSXa5l8RxqhIOQCQxerqUWbbZA2i+wuySoJ8PLnR5TRtkned0HJuwAc2emwyMNpTP0QkJz20LBwHzqxs8qMn28cDGC9dh02Q7FPP6CXQs2sas2v0PiRwPA0XNF/MWaowQAXE2SqGHhNbS90clmbXT10RXGb8dRNmvKSjkAhEf5KlKcl4pS0NZhONHdtIbxN0mVuW8apVURGEWsnEr5o5Yb/qMm8rjj3S1EZD3YJmQM83f4UQBwbLUtIc5nRCRllU/nwldUq7fMcKbPvBPiQyGGg9klbqt199zuIBKzRcEoFaK5mQhxH7MuQn3u+4F9pNzslbIj1kI/fTtDoVK9z92x1MeRzfduZfvrcYO6nWS0ZevY6MTr8n4FXHPPeUmAOgA0HInjykND+ZKrI2nP41uUEnbL1wkX4Jzx1SDPcldy98b6/s8WBEuFcO2IxFvIpVDqNSQnea86ANz7nkS0JN3/WEN21eg/hSU3y5v7xSdnHvjj4OX9C+UbX8dxUu3P1IgwD71DOg/J7NhpJMP9hC4ANO5+pgRg2FAnDaRP5JZMyObO7d0rbt7uI82sOFfPL/QtU/TwWE6eVqaLhB/esICvzZ4rt5k3mJ/wPYcHgD1HBtObdr/l7AomcXVjher7OdtWSk4OvCmu5zQ5TfxbRp9nAaDbzmpm2punSnuRGn1h4isPy9f3+cB1Ya+KDJTjeI+Zt/y1tO9KXtLOX4feeWeHmo1Uj7didlIz1/loDgycJ/U8LIThDZm7LAD4F7vK7pd4yfO1Zysd+G1uP2fXJU5nTQqjqd46zSb8juXWSvgZsOXan/sjw6csUljHj1OPerOMHPIYoPTSCsU8+peXkPnTlDcXlWllt1ICYru+Afdjt1DM3H1JPRW4RFAZ8/13/TFUkDo8Vr5zfhl/S0NIJCVd9ObWK77QHgueiWeJ1UZt7nwvF9oiq78EAA6mNt8IYfjzDT+oZT4nu+xNXc8t4gDg6LENDADMnTdWBgB3R/UUsnjqKxgA+LSrUHZ35WUVZguf81hosXDwpQFgnJ5g5fW/c5+5/XWzEvx3nkrJoNpespV76zT37nXglybspgDgbychwBh5dhazeZjQ8uc9VLC+Dt91UsEB5/uYio+/rgYAQbuTmbzeCQLsRZnKWdYCy1sqYmjRAEan6REfOWogTwULZ4npFaE65FPXzuyjgU/5YQ+acwCW06OoNSPHMFtrnZSIptO0gX11+jT9oeA1BwBdtAQOXetdrWRQlO8QQiVFRdp8zfm+ZOGkR38kqulXmgKAnYVnyZVrPAMAunV/7rvY1tOYfZGqLs7jmpbGHewppwGgyPgZKQ3TUOt5qZoDgIn5PjqXlglEvnfBnN+jkCidaec+eIpIi1pS+0dj6MfP60x6giX95u4RZu1f1WTsYiNGy9eBufhMCHaud/IR55x3s48Il+lcDxauf3Xjyh/d4PvM2sPG0cP5nJO9uSy6P71oY7w4cGWHzvL0sHDpgmpBChaHNtK/9EtF4oVXpYjmrsSZ4xzCJ0u8fnoJBBl/inneqZBaV9OTr/26kFpVGSvffnyn+O6Avkep0defUl2ZHhQA3L/VXEZzMDqHinu/lm1zRqgE7GWsGkUFgBFxzn+s5Fi1xkcBAPNa6fFWtV3Z7boD6Stlu4RYmmIME7RzYXNE4faJP879/cNUeu6zY0rMFXE2jAm6p0evGd3InWnVkqtIC1JimsKz+dzMF0Iv4o46Xe7FCydqXveL1HajKjbabKWSlC663J+aNyFVsShXizf0mS2DVZdxvHdoG6ZbKzP68KOfzJWxD8mjCsFy6rl0rcxPsYCPeX+Rze9Swlskt+QBoEWqJr/nwnIJACSUfaK9Lu8SNxZvPIt+3yhEOn/sOUOXq1eR3e2VW4eXHBDCIPuz7EROibUYzgGA7HYyOddHSCotXHWaaGgIKdKDZ1pQAHAh31E6rpNgrWzxTJH75xTxc0bUSACgrKS51telU/0fdXRW38UyAHjVd7m06oWPOL560HJ+/pvpFABk750pIrhTbSg361GsOgBY7hK+bzT4wLu75SsAgN8o3PLjtvg0cbO7SFveiRAJO9voMAMApmuESw90AjvSJduaGAA4oW+roj7T3xixiN56XO4eITgpB0x3i5MNMTRlAWCBjdBPGL1VuHnBeaiZCOyxiYvFDX0K8iSv3vanvpS0FarDtfy54f41siFTe6uonCPnCTE/UkVKcgJFSybUswtn2WYfCwDamXOkagMU3OFcDeKXtZ4uKtvINu4Sos4ZI8J1/nnH5shf4voxiin0ukbhJoaowgj5nqGCh59ceph9YDtYhfuX2enTI8w1iMv6Vfz8c74SACgxdhbhMdDPFdWRdacNpGX/KUoI1P/tSNUXC30jeV3702/TBYvTYb0Fu8zaQEViPx/qRm/KEmrQ7q7NYcder2q2Jo9OowCgYuw7ZVztpUo5ANgXrM46B45SZ4zlzEF1oeb0XSuhXP9mXvP1GkxlsHB4hxkxg8u1yYnrMSQrZ780fUGCtKe9Aztve4bsydp3Qu+IXy9J3PkzksDVI9XCzF6TVjkxIpJiZyWIKs8pt9lqudz4hhluYkOebxtENJhU7kjJcrrH5dZUaU0p6z9MQEDay+P/sw3h/HobNmWuPtHvYUCNMddVIUoPzyuSEJ1D3Cd7yf/ZyrBlR53Ev7q9gHzbKiE9++ONkgTecDsnwr3LKJaP2lHBt0tZrLTmzaer2baZW9gOt+yoCj/hFocBhkKE/dLA/wQ2p4c/4NZNFGple2TV0FomCtatbENz74e5De8zLkEy6NsZtmyoGgcAK+IqWFsfQU20qmsgaT0b5QCQMmq1jGvzgx9tLcT9V/b8xd323Evbz5ghhPUvd+A0ioVar1SXZG5hD+GcCvCJkiv8CsQNndZfzC1ZEyYf/1z1QubZdta81dQ66lln4W6W4iNZKhJ4z34cDwDO5kGKX+eEq5zKNjSnjVfom4lO2KsdzQUd53684euvLxDny0zZpJVz7i3f1pJmAGBKpXAJm3yRGdXz2yzqKPuM27DimPj+0vBk+dKArSR79Vq9/4Ypo/MdSaaGAIPtrxoaACYrwAJA0YUDBACuVf4nOn2myeWP1sLlo30YACiaoaD3nHDhAKBXlynEdYAx1zp7Afe0dDoLALl7YtWObVnLAUCPx6d4uyBL5sJSoUso8fpkRSe9UGZyxSV24BEBwUXf4kWR9h+VSBlf+6USvIsrG0wP2JKlaHusik1uNe2PHPxAK5zIrbXVDO43e7m9bR9ybyfby+NuGyntKe34dwoAtIc4ygAgfFid7FqHZK5y3z5x7WvPxynBYXh5pNBk2uRIWR24TO6n32fXZw6XAMCMdqO4LmNzGQCYt72cvp2Tp+kSk8wCwK+iPdxxzwbaumYODwCnsg4pxdFWtHvPJ33V59dvNOYB4HS90I2cN71QwMtTLRuyepEmSXUxUlQ6vZZs/r5aydQbkyz0Ck53DVWsVB/AzbxkIl1784pK4PGnnQF9xvX9H5F3s7ZaBOrhj4Fk9OAdEgA4q7tImn3ukbheyKSp5Go3ieSkpYv6k1v3WcuuAbJirVIKAM7l2NEa7YWKlwZMEPIj5v1kz+5d55/3ag5/n1lkxwJATugBFTNYOyNSkWLYIAEAWSeGblU3lwaA+AXnpfd6Crrfc02a+ptp+4Sr/O52onvcFbqDtya5invQjzzNHp+TwS4dXcmG2CoIANyI6spvfLSRB4CPXZrP44gDQsvDkKXC9Yd/mW8lUQ8Ez79kZ4lsq1WK9OujFf+p6z02UrhF4Opj/lluOLvdN0We5+dLHNMayUtfTSWOqTazII3ys6LurErLpsrMTKRLdITGz30xUrp2tnDvee8LbWkA0J40kweAypQi/lCpcAXF1nFRKhJhdtCNFM35TfU1N/0jQevL56sDwOYuHykAaHoGccPuP0+pvFPUTagSzFiZx784s06UFo1WJeLYEx9a8JYBV+jiFUIEdvirVfSsjTEibIVrZ7NUTSrpMDqPzu5tyZbGWTN52wS1ve26ULXZa41ADIeUFFHqW3lZMBte9yerzAq4+OEhMustzTgLmxAuHdzbUoS9QEPQLNoj/1Vdk+rg1wcAFnQQopCx9YOlAJBi5UqWGQYoiX7doLOiZMxd+YF0rzlInbX6zl+684QObduLDxtH6Dund8hud8ykJZnHqGqDQsE605yp5j54Icm4GqlCDBPPXuJm9h8TcgapjoKK0f89SyXYuD//GQMA77rp0QAg+zWDHLFyYlcfzBCykE2V8kWRR5iCglJ5zvZtcgBo/SmfBYCHJ0cqAGC1/yEZAJxcdY65mO7I9bMMlgBACOVJvX2pKW1BlMMuEefjleDoP0y9OWDa+QFTNLFc6SybfCeXHdev5f9ZmLH7gXAx27g2gpVlUfefTrMtruHMCq45RetpvETJbNu8cbk4cXQsw45ceoTetfIF11nxTMnSqO/cfENowoFAnRmthJ6IFqvLVQ7eJZn3OQCIy9hMJj3L0U1oAgcAh52MhftDxq0nu+8KtVoaU5tL/F+9EC4WW0uWyQDgU/FKzte/u8oZuCauucpQnh9FGg2cm8PgroHs0SHNjLa0fbkS4i7UrCCWMxJVTNeSAT35UYPqqdEtPGkAWHtNW/7Suhm2OZav+ba6ulR307bid3evFbLzBxuRiaeuUfWTp0kBYOCMddJ2d4RbUf/+OJkxeXZdBT8AgC7vdJUQvKVHrbiJrNQS6ft3gglbtqNeYZWUqKjuv5rr5riNqfsQQgoHJrHrdKNUzhXNH7HctOIcJV3eM9ZSbWzkEyUkLJ1YSD+NCOGvWXXghkV0ZytbNYmwTAg0JzN9EnXxX4/btO7shAt+DAAE3h6ixNHT1wTxeR8NeQCouecornX01Yvm+7NyEtQeLBKqSPRnCpd+Zp14zS/U3qwildsN3FWIvnJvgPTmGnmzc/t5JAMAjiMFYkdZ/BbyNeXtSUWgYO3VRAr3HK8oEdq7z2aPZLs2XCWXcmcrfKKb093Y/3eYkok5/0kFudo4R0XksvY1q5zxST7qd5qipSc2dmnuGtp5UeUdfa/JXOtP5krfH2h8zWW1fkgBgH2AOdv2kmAKNqVWi5wpWTNOVAtz7ISYj/GP6ywAjBqRz1mWLBaRlDf8KfOrwzOyNaqRBQDLaOEqjDt70zkA6EqPIPdGVnB76iUcAGz+9oNuaW+qYlbbRL1ik+t5ZrdhDPtyf1vx948nXBl7PzPWorGGSnPyJwAQvKeWbzB7LvOIKJbZHV2uNjBFuEDAzlxINeT1/E71tCwSIg0VS8W5jF1jGADwMxcCm4gN54t/CsSDnu5+ymRCOTdGey7XYKHF+T5IYxqu7lTikF0tCsSNd707gJvpdFCR+Otrc/HCFjfVRvhZwn8imFU4XATk/a+RnHHTZS5ts6BirAxT+Lilwj1R9eGOCunpMM7CcqeiZ/5RwWT2Apc91IwGAPfzQKvicAAAIABJREFU5dyAPnL6U19DAgC9196ijTuek4+sldFzAz9TABA1bAH9SF4hSsB2//dK5ubsKz0lJ3fFMqblwiVmDQOL1T5OsmQBwLbAnVhMn6xe2sWUTrPeIjOaLTjAH7t9UFvsvkGxakgviYeJkDc/7Vuh8Tj5skovSPXxK9IOP5UL1eUn+7Brj+ZLAeBSfKOsrHiK4ulqwWHUOLycVI5fquP/oQPnfvYxe3/Mf/ox1WgnLtpTaNj5YdOPG9rmPuW5toOSXovX6icHgGeJW2XObj5KnLV2Rbw8evNgDgDKHYRihz1dE7nRklrissyILN1+mSq4sZ/7f4V9eUBN6/f+c/fdd9t223Ycx5EjSTLPyjxcU5EiQ5kqjUKU5lloMJQpIZoklUSTSJGQTBmKkrGQOcMls3u53z/e+9nn7t/h/s5/Z9r7fd+93rXWu9aznqUYuk1DIv/30h1AQs+BF1NVa07OUh1mTqhRHGPnSh74fZmjECuvED+7HHOa7/UPyQEA9L2XLNmNif2D2brlLblFTQJlNsSJ2b3UUZaV9YiN8YskFbz5VczekOVsWKyVbKZDK4qJlGYtc6d3UtYnW9AWld1ZAMjRNVWk9iIn/6ycscqSXcTmOs4eyz0I6cKOsie2z3dkGAUAM46P4oNUDszEzXMpe18/DVd8b9ALqb16+mtzyQQ+VJE4f13BdTrx4mGhZthL4UYwiQe9uFLL7nl0VgCAk1MIC7bT3G5cz77hP61I/d8rvvlT8cabqwdTLbOJ+7fXS58HgMWvRlPDJ2TSs5flUFUeMm56yF6ZvUN7HgAMjxOEYvaqPoP/fc2Yy0U/hWceyw1jq5v2s1dDe1LPQgjH+v7izeKDuzFTS7IQnrP8lPb6WxUAMGnVPCUArGBiSar1bI4Y58rT38ECQNm9icqJM6bxJ4/c45T7T7AAcJXzYOOHrOLLF8Vxgb1e85nnigUAMClxFe9bOH+dEgBqr7ZXrghXo3GS1kXpkYXqd4apCfPUA4ARjJrDaufYl9yERWtUW2BDHdmvJoNsUhHG0ERutZA8dpxqwqbttH6DLWcf4CY4KsKEgtRDQu71fVRfs1Qhusye33zwjOCzTa3itLTK+LZJCr7dAHd2ee9KtqVFTwEAcs4bcPNytrJ7j8eq7chJUvDZmEtq25+GPRCvM+vDHLaTbituV4iZUDV2Jfu2ByERC9o7mzOtKP7pg0q8QcB0R74SXheHPc34xngSm5oeo/NTwbI1M1cAQGVfQxYA3vcv5oYEES6UkdOktZUp29KoCLfN3QFgjuU9LuKmFQcACd7FzMzZmZINYBxc8eNC0IggFcdUj2YXFv5Jn/29kTG8dUBI9h0hB4CcZG/Guw+pCDrWoHZ3y5omMubmaT+tLAWASl0Lesv+25Icda5RHpH4QzOEoRFb5FXehM0h7t5jGgCOrZgnemz9rdzZh09ixIU6p8/xqXFB5Oxk8lljAd9TYwStFTMpG6YP59MhRqLuXj68IkRyI/hH9TPpnNxI2avxYdTMwHCm76lKbttTNdJkdLKPHABWJb0ku3gHAXuf7Srwr2zWMFXbGCH02kJdAMg8fJQ57hJHNWAgXya3ZwHALmOkNgCs929i+0RO4aNLp4o7ZP+sx8xYlZoErtdrUnpXk05abSC9yo7uoJpBz3t8R5lz8Cv9PbmeBYDmny6y7cfH0Bk9L7P06zb/2QWAaevE79etlE16tUdi1LTzdwn0Phu6+NZI7bglavL+97WEz0S/0yLqir0UzNDmYDmbtdGVdbU/pbrq3oIDgOeTF9OK3xy59tYMU11ymAGAT7u92E++TfToF3fEsVW6fGYAoCA/UaZ1gVFnMr1SDP59D+9wtVcZuuOMItZzsOptl+fUqY2HtBfv6kwBwHAViQA4R44XCkvy+Q6XmkTJ3lf/RiKE96vIEWFwRK4OAOgUyygH1wUivKi9SQFf87xC/H9YXij/bpQtT7u78HZ5QT9eW/PhnWhFhzx+7cczivlGNdqGFgc4nb2lvM6Rpxy/sBtJOnUg9exuLesUz/KkIeiQ+SbUGEuSzq2rqyOGrmBhVwAI8Fmh3CmYcwAwxmSActqyzfynfjeo4cO8WADQCiM5mVYutaxOs120o+NJ9s/0BQwA/GJYKS5efFaC4HCiv+K9TbYcALQrXPjrV28JADBvWqT4AGptNtCbx29QVvmliGNs/iGImlbXTwCAXKdJ7OPdU/nuxgslwnC8kpDxbE2KVEStnqE8Z1THlCw0Izy9BgtkkXPjFBNTD/zUOQGAsenOrP/J9fp/Zatz8tWtakkBakWpsGryAInKquuezo+P+FcEQ8tYi4noTFoatSuT1mHEO27ULjs0iu9QX8sBwKFm+rLAtfXib1bleWrw0ALAIPY7a2W4Wxx4dtj7H06iy4NMNvNOIh/FfGP9O3lyc7p856Le3WbdezYw67at0D6eGc48CH0rsQdec78SIF0DqYpK0k7hUsa7ijvzoOq2HADWuPZibeMaOflYZwUArIvN5ecG7pPML2KNsxIA9JbU0FtfLWS/nHstdLsQTQGAyc2dxMW2IXz24f2z+HfazQQAGOqwnDtQfJ/t4H1csKsfxnG3+zD39m2nvvvai+Pol0rA3J4j95PDYKc40YCfOneK69jpOC+73IXKGXmHA4D880cZ9A4Ok2y9QVmkTU9G9CniQZVfYQHg8HgrKmP1QXmJOS0YOZBDzpa65eIib/CYRQUemCB82djwQ3vSNYJI72bHg0KR5xQVACzbPYFxt/Bi98qXStRcD+8C0S7wucs4ALidQ/oL+qxwFQCg7uoyRYbhQdnysX8yrl0Wyqu+k1rF8oJfxO1/eXQV7xOcLdqi8vs3SOXSzliF8R/p4j18Dp/QBgC7lC00ACRflvLg3wwhbZNmL3QksFadSO5igp2EHCCZsWWGPlH80JH4bYoTO37QQsl3sdHf6JdcGVU8IIFOsvaWAcCBHH/1fVe6LTD69x9i2mSwvnQzplnfYlqvN+kdeDo+gxms2sfG72ziX21TijdYk57BZZVO0gWAnc0sJBJYzfcWeoaoS4sdzrnJ+8nUdua6ax3Xq/AqF1N3lQKAl10D2QWR7vpRBsRN/fC5nuXbVzNvn1ZSI9J9aZvaJwIA6N/Ip9Jm17Of91WL157+agxbdJB4Pfc8a7hx2eouprXepAhVMVVdnJRxcr5EEC7ok6aX69pZaEQbAGDgG23Joi6evVAHAN5fcKEAoDjhEh/tUaz37994B3vorLe/SD3rGUkrPz5kj8eR3eK+Y2tXD6tYeuMtD/7w9Ic8ABzXiifjfaF14YcMBHdv21NyAxJY7KKyFCfeTvGO7nimlO5rXihOeH+PqcLuqYQT/db2ZOF8xkL5LptlqqPfOC6mXxoT2VqX/6t8BV26PIB3jqyn9o9fwk+e1k9DjaXbrVeatflKVxTNJ6jHrSSHYOdOagudzE/IattuowHgVkU1PUJG2tftjDosLu77dgTza5tWI47v1/MycTGTtuZqv//qIX4X73zUAABWjI3igj+SXoJR+7IU4aNHUpP9yyQ7wb1MW5iSc520jZ0RJRzrsEAFANmyjWyusSt1fW2JtI7Gb4Ew7noVW6EoFMfXdUk0V7Bjr95vTzLokmxL8felUaZKhC33lZwc3T91FgDA7LOpRHr2phPvwdMlS7umjiBAXv8xhxrm5aLwdAMTsOa9+PstQ5/Ij922VADAWD2fn4agda52oOeeO8ZllqQrAcD4bwKxjIgiDoRTkrWwOjObTdNpJfzJhYrXLyjeJhifXSkucI+vCTz7tIWogh45skJ7ndPcoWhbkuvZb8ADQJvRbvRiu48cAKzaStHl2tFUY+xSjbDPFleeBwCbRWe5B60M2PWnfFSlY1yEQ7ypRID+tn8jzi3OrQUNAMWrlzEWH1IE6zRSx7+ooT/VIbSdUJteyB9wnc67DNxA0tmJhO7vzP1SVn9/Iw8AA1pOp2CwerUcAOZ46vMXtZJ57X+ou59lX1S6ZUzuvbDLfOHc0V/FxTA5GKGt5VMqTv5DeKJyrjyTLttA0CUO1TY/hkj+61X01kAIm7FIu+GSFeuR7Kc9LW+nONHWnpWKs4P/Ehd7qDfFWy29ISiV30T9OjVrJbcl/jeq2Gy7+L/7OteZjd8Ie8MAv0AWALaeDKfo3TrU99P9qJEDbBTfNhLY6nfPMjX01MNJkfZyoHCsdbA4x0sh++XZMZZqqr95XWUA4Pw+kwOA7tbmEjfVu2VvfnqchahlboVcF5ZNO8o2G3NWHLNzSIPy8czJ2gAQkDOD3tq5kL+7tK8Q+zqSeh5K+BcbhuizmG3L091at2HjHXuLC1nU2VUIOfFSsrDtbvYS3p+wF1rWTP+h0XbLaks/Gr6UZNFWEQM+yfo1f7tTLcv9RRAbE7SMNA5xFZvVBz73+dWa1VRd3dQlcxkblaqNZygAyJxCwvMVO51+KAAj5sb+MPPYvtVd8WHnqwgB9J0ld5TOpja6GWumsQ+3eVPG4dJ4E1fdTRzj0nanqHVNfbhBSwyVALAyaDSpRzQy/M9zWtyet5zf/GSdZLN2pAQ6qkYAgEEtDDU1yNowzZYRAFD8FzGQGa/SqSEh4T0BYNPJd9T1eS/pOScedAWAop4JvO36SLZyVbn8SWENt8RqP/vhniVrfqZE1mNcd3ah4xHdj9fc2SUxBfotQ9QP3XLBTu7iMjcFAKT/cZbdlWNEEk4OtbzjyMHCuKACpcPnk5TD1GMCAHSzjOV04k1JlPg+R+13FQwA4HDaL3Sc/xq2g5wsbuCm2SoAsHz5Rah+7CQUrSuT2X29x6pOd2QAoPC8mkniVw9KbVeqPzPrZ5YzERd+Fxdoxmoz5t5SUs+yIGO2LgBMak9YSJW9YsVdZtvW+IcufVqMuTYANJZE06vd5moIY++jJHL9564e9LO/NSvTsHso8de9C0wYALh4mbijIQEd2YrJN6ikcZFciedKFgD0b7toRC2zTHfSAPAsNJLyPvmWjZ28nQaAEbGNksE8nUPa4fXfek0yEZNeg364+0bcny34ffnEA4DpYtLFRhHrLAAAm7dDnlhnIvF+xo49LU5u8BtO/G74FgL+zjI8LDxSkDat838hgIjAToTednXYTaY90yQ0JRFoVGCSQOvvOCE55Q9wJfClRTk7ugNAkPEwFgDGldZye8oM2QMb6sV5LHfaLQTYHeE8z8yXzC2mlABJnBYTJtbj/gzjZWchx5e6XMElqvGnJ8/CMFfZuG1P6W0lmaqlETXC30cdRSl3YmdLbtJ7TTxbvnMIfX6Xuy4AVG7YynGTt7BhG5qoCMuHgmLNO2FpSD86q3kqcyC8JbU0rIR72WuGAAAFfSdzFWfTxXF4vXnO9GHGMXQzwtTgu9mDGzrem7LcRXrstsg7JZ89qTXlk15Eh/d8xQNAo8Nifs7S89yFqd5ykyVXqHHbSRMyHf1fJOrLxNZUiMr1VgKAmfU8nW4u3eiS493Fh1g/xfk/T+IA8OdhM86/aBZTuPeGXK6fK65DlytjabcE0sskYV17AQDODw/kVqx10S6wWcC6G88jQlHWUTvo6URRqBecnsCW1K+SodtlV3repgrapaqt6N65pE7gvNzUKdTri4ro5DujJFuq8b6e0NIxVKifNkwcfFJTAdfs62D66NESat/QmXyKxwMBAJIz7yoA4NQrcqA8fE0mmXCnBeZCkvIIl9eSTCSwkDD+WL0yIBm4tCbutrcdF70pXNd4zxjq75o7XEBKhjz9biX3uj6f2zruGXN7S53kmnte7RFmnXXirzLj+Ye7SYAwIsNeGwCiJttoRBfmNKlr0N93C6En1ZIcTA+dUO76+flsYrsJ4vcDklYy9aNtJbar0beH+H6FWTnjt/FXebN2pEb+U6fLEg3xulbdDTs7ONkgRRXINE/rLxtovZJDaE0oveSKunQ3ZhLB0I6x7y+RfkvKi9uRL+WZmjhVzVZas5mUDg9MWatyv6tmk+tduJZfH2MucNWBnOOft7kvF8h5YtnTNlxiBAHAvcoaIDcaTlpHvFtiRbU7F0+VHzSS2014IRGCyIOEJlxvWJOGPp70e5iGCvX12qxhaE9FLacNH6nJlPf1UJfWvXk8mdllQGr2z+/3VAKAX8IEOjmAoHAWpK+TO517x6budlYfiif00rjHi3Wh9IybTrKcck/G/egAGgC8hx/9qfd5R5WlVrmuu3kBAAayduzhXl3EPxUXP5Abl4fS8+w7U6aTWQYAykaTzJhytYLWnjVHYRzgpF05/KMQsKZe0f9dIxXqZcwfeE/Qfkbd1cmokSYEBb6uVwYLAK0xmG5jEseZXLtJl8SaUwBwY3ggPziFEBL7h+3qnZi1XPabPmHqOXwwSGIj2nZUQ0xvxA1VKpiFXMcdu4Vj69uTAlObbXri4qztS6nMPnEn3W3Fz1oOiaFiD65RvbxFdmROohrbazWExMHKe5AGZG1Nid25ZbJODgBdGNIFpz1tztRdvcfP+l0NZU15WUoP1y0hYIm+aTwA9HiWTerVbfbwJzoQEESkQ5HMxo9EqANcArpGB83QQVO80GbOZzKve/Et6dWjkqhzlzsLaRfmMgO/+bGJsl38XeuvXIDRakHoToxW9utgMS60ILWBLt9rR2CV60hK17bxM+c3/qHQ3stfoj5G9C3nJ6dOo03lOxkAmLNkENP7CGmh3enRFGFCdktuz8mn3NTqy6LxvOedKIzoS/jlK00VlIEPKUe2ym+UlZj3ZVu18uQB4MkuEntLrafpTXeGCAAg3HgmLJ5OOFu+61ZJdnpg9Ha5+dI7zHSB9HmP6LHy/5vpBACDYg+dhvsblQCQVT2YAYDfbxhp7I6xAWZsm/eTJff8vgz8qbBlGsSYC6+R6EfNVVJlfCy6txq10/y3FC54a61SXrpY4gKPclrFLOpjSO1PeiMborWKK7m0Xvx+y9TOoi4WhtjyqXdJQ6zgR+05nYvdxYnWTbXm/Iz96ZLiGnrj6GxlwolhJAY0fSrzod9AGQCUH7NU6T5p5K4GRkgM8KUZiXRg2FtxgvfLL1Kv15P6kWFL1Xq979MRwgOVt8biWuw6KuSUkuaZLvtIOH98Cq8OioZ1JFRNPmp0Y8wzUtpXbb9GSJgGbtSDVlTGdu8fGvoV1Qv4w8M/atx37sgbnEtKuahG7SO30f3yP/NfE+bzzy0JhvfU7t8lD07P3IPHzA196KeblOyX8uUSfd1n+A3m/ccKJmhisvgATv+ayqSNcZfVXJvEfm1BGmHZNz1jtIr7swCws91Xxu4rIS3LLcvnAWDFVg/ZnguZ4oBn9G3QkKr0sfGiZHRyjZZlNrOj+VbqLnAbRgYLy+7Gs8syfVVXrOezL7yV1J+3A8Vr+k9ZzXjN81UBwLY1W5QAkD3zjobOnhh2Uw4ArmkWopoJ+WMZ/0vVDr40bTALANf31MrGH7jOA8C37Y8EACg7QMIr/XzzhNZ5pDdVXOh4cR5a7y+TjF/DOU72dapkkQPSXcRMqWKpOztTUU/fbQFx7K3NO7KnH/+ruGjlgtEMAJTrDeRyx7UUzAoJAcoww0UCADhbeYkXNHK4IE7kQ4ee4kU+5/31w1PxzOB7NAB8r9Ji+piYCAlpt9WeW9gJtvnotpROSAn1u00aDQAfJ/N0tHXWD6/179dw3X/YfHZc/OGB1m2WDnO1chofGOcmOT88rm8uXPmmPnUX7QrjAWB1iLq438JgthCZQeCvz04flc3vXc+Ht/rM2Qbos24pnqqVhp6UY/YMRpW1iwqOWkFsUN5Aef9ebQUAWLg+VEiII8xFCaUn2ZzXKon9i6xjBKdSdVDVI72OG249QgcAUg5myRD0bTC7PXSaDAD8txCAcsnA64rIXUXyM0nVwqH770hNSHiYiBz0GVBGdY4mcZ29WzaLE9yd3I8g937L5wPcN3P9Yw7wfraJSgDov9pb49DXzqWKS/kyQAUAYR+7iYOc0pMY2bFOV7iqSYsU2asOSzwol5hrcgDQN68kJAYWr/nvqf78meoKrrTumPjQm623pOp7l4sPuGzVCNpLi+RwrNeNYZLDX7GzC19QJ+ZUa6ijk/ETCb55C+l3ZbJkaM//fadYeYQvGuREP7ki7fu7ITb8h0WneZ4E3Bdm/1q4tuSrxok8urM108f+H9SOwXFC3rJxFWmwNXFTiWh8zkSn0RsnzTFIH0O8nLx7K8UBmGbai2pG76g1HfiRxI5sW0tZ5vL7zxTfp9ou1waAYzNaUU88O8gmnjnGAgD9gZAlr+yl89N40OL8YmbFA3c+Jq613v8+y45f2ff//d31a4SQv3HkcTrI1UoJAGt1pohCE12Qpr1wBMMCwOxgCxUANFW7agjLlslDuUe5j+lYF1eq52ofrtUndaQ37rM7BwBxi9y0G9eSRpg2cX56JzLyOO1Hh6lu3dTYaOO8ZlR/vlEBAJtXbGXSNhtSEQsqhX0Fa8R1Nj3VmgKAiMn/lNGdaD5cWLw1QXvowGbs4KK9ahzspUjJdvuv10yD1VRRcwJoXtsmWKPt3IKLuznrJaeYN6F9GfOVHbQPBJ+S5x86JAeAEyueMcMGXlbsDBkhUVcbAsbzw7+dY2Nze/9QjVksOso8dCIxoK9zSfXRJFM1SJpNJPSrXYcS9fvJYR2XrT2CFLQu9+ZtfiO0hbNSI2URMfZsVtwhHQD4zA9lAGBogAXluf6YQbr9Wb7ecKRsydtfhH4tbkl209aH/hQAtByoJ7FZHtebmLAbz+RdnswnYahDpxl+cRTz6W874YmtGs2pWtOG3WX5L1LpK7ebM1uPdtTwEjodIug7rwJbJsEwS3lyx24FACg6qZ9+fsscyf8sQ0u5D+NG0g6XbP/Tlazv+kyeZjyKAoAp58N0AMCy9IVsUk20uENOjUlkTNqTTONfrprgZ93OqazJ0+lCxw3nhV8mEfzsjT65tKWzv8RuzN6XR82Z9YbJab1DsgtaNM0U71XdNYBdnkbgTnNdnpKyhMRamXFaE22944lQMcGYA4Cqzpc47xGZEve1YmVr7vnJ5eyf21eKQjPI2U/DoRg/LUhh3HCImptpKKq1Gbpm/POUaz+PEq8oDlE8qqjka9sMpFODvCSSwNrfEW+om0wIaE71bSuRXKMr99nzeyh1faJjCEnubwqgAMAhxpq7bRQoHH+j7lywfo46Lx+2fapopP0+6goA0HngLOWLItIl08HtoKzLZ3++veNl/pc5hPo7bxvJOWSEDud8D5AowJYZdaQmxTSU+mxhRs3fOE1n6pn9gsqM8ALnm/tSv3UinI2Rq9Sk+Po7SZDS2v8l53w8Upzb4Fv+wvxhDNMpIZfr06kb/a3rLO6TojPXK2yM0DCN2F3DwSVyh0/ZPADcNBjPa2ecJvatVE5PCsmU/5m7jfE5lkAzF/9ke/5DEh1aTuzdrQXz1Q/Zb98c9qNtHRXrPV0XAAwWEuhm2NGW2gBgtUBN8mjQ4QI7OTaBK/h9EZ8c5MsCgNdu0rvPuz9pHeoQH8+f+pVwKvrsLFIAwKKRpCRt8PB6bs4m0nskpyv57vKwRg0jt2FfMg0AfzdwNAAE1w2hlqeS4hdnqzGiOvS47C7L79lBebr8sIYN2DNJWxHYWKKsmHWIbR+2WAkAaa0vi9J4OK5UZaSlbsVU+0c4ZXVBTY+02JAISqGZNz+ovYwvNDFiHVcMVPzteV/gnYrF/83uWSQHAJes1aSe8O0R+l6PfBoAjscTsJzvtGgdAPDY5ypb7fpUFMa1ozOYkx4kLZAftpHetOlfbf8mJTjLL3xUH1Qm5Onzvs16CKMXTxE8H1ZpTPjxzfXa7x/4Mf775BQAnJhqagAA173mC+HLyygAWHt0KNd/eqUcAHyCCaGZRXC8eK1RmQ78sHASV7JWaFEOtgNU99ev13HV308BAG9DiQs0tvEdFd86mb3drb34mV/aFwEA/LgjwvO1l/hVrgc1goZ2rtv1jk51Fh/62aE14i581qKCB4BXi/pQZicnCtUNBhqqJmpsLgUArrTatfcKITu2Oni9KNn9ds+RLT1xnvUe/YCLs877KZJzzMFK8ToX+zRwa26qc0SR1UtVeLvdnzuSdVVpmq1Oa5pcKRX13KJLlRr6+/DiQeJAOlrNkhh+I6MoAQC+UMmMRw7pVXVwNEs3xBazG4I/iDdf/eIeX2tIutmUXvQWpiQdJUQFvjuVOVeCNcqKASAt65YsLeW0ZNFWrDOmN3k9EdxiLwtRpk7KwLWbxHmsKy/h3To/V/ou3q/9WK+cn2k5WO9nC8VPH8Q9vkSi0/cK5gkAkD6sgulmoe5aGiIbT85mVbF0VtNwGgDavCONJO8uOsdX+hr/8FyU8VyH9lwzT5xTJ+MmPuViKuvmayTPqHzAz202Qeo8TYjNoi7NqqcAQM/nmoaUDPySyLQ8P4gGgE0+5ynhpCab9e9OBHbpYTZdVAt7rQiIeO6JK7JwnUDZ0uajhIH3ayQ3P/dHJD2sfpgMAFobDxCu3FWD6/a6RykAIDGRcHcdSAqXf23eQ2LbCvdPVG5xeciviiKRgylXxmuM7UCHP9gDd0OYk35OlLn7CFHlpU1+LVGX/fNtugJAWmQH9lRcOHvtbYFEGL28PhMIUlIPKrKOJLT+yr3Bj+i0l03RKmSTrCKYkXY9SAyNJ8QGkTNidQOWksbKy4vui/e7ZzNPHb0oTuGnZvzCLx28jOysymh95klEFl948DtdcGeTbEbOXGXCTVeDYfcaJVuv3x5zcbLLk9Rdmyd36ibU1xPdqFtHwF5Tzl9VHlqUwz++pK5JdzYnJ9QNuwig4MjXMUyw7xGJmhmwg+QKnq5KIqflS9+FcmN1XYmR6wFSfeQvJQxQWRry56Kk4ZJrQQ2S94/OOEoObv61Wdz6B5fZzI+EEOa+nz5rts6jK/V6xn9GCwrfvxCv23beOckafTa9x+tU6sMiAAABIElEQVQNOSeOrc/OTA0bCQDZfb/TUyJC6SC7dPFad6Iy1ONL6FxB+wRGKiY6Wshjf1W32fY8kKgDAN/OnWd7DeKZDlbJAutYS30YUMKEGY+nbZf5ChM/txAnkLFOTWw5pGke++acF+fQt1Yc9K4HoWzboenUqDb1grPyvXDLQo863ruBr3CKENXgrlWxSpPLIazPDhdxYv6/azG7PezkYW8IW3VGsrruvU+XUHrDoovE9c0+Rtc1TWHWFvemYwoI5PRisxj+wMHLDABkV/WgASDO+7QKADrOJIb+jzcTqaIxpkK/+CPMi6JZcrZmMnf27ZD/RNCY2lWy7XYEayx4skusqk/Zeyb2lD9Nd/nKOslma9iU3L1LKABwPrtKIiT/B/yJab4wYSRuAAAAAElFTkSuQmCC);
   }
-}
 
-.editor .search-results .marker .region {
-  background-color: transparent;
-  border: 1px solid @syntax-result-marker-color;
-}
-
-.editor .search-results .marker.current-result .region {
-  border: 1px solid @syntax-result-marker-color-selected;
-}
-
-.comment {
-  color: @light-gray;
-}
-
-.entity {
-  &.name.type {
-    color: @light-orange;
-    text-decoration: underline;
+  .comment {
+    color: @light-gray;
   }
 
-  &.other.inherited-class {
-    color: @green;
+  .entity {
+    &.name.type {
+      color: @light-orange;
+      text-decoration: underline;
+    }
+
+    &.other.inherited-class {
+      color: @green;
+    }
   }
-}
 
-.keyword {
-  color: @purple;
-
-  &.control {
+  .keyword {
     color: @purple;
-  }
 
-  &.operator {
-    color: @syntax-text-color;
-  }
+    &.control {
+      color: @purple;
+    }
 
-  &.other.special-method {
-    color: @blue;
-  }
+    &.operator {
+      color: @syntax-text-color;
+    }
 
-  &.other.unit {
-    color: @orange;
-  }
-}
+    &.other.special-method {
+      color: @blue;
+    }
 
-.storage {
-  color: @purple;
-}
-
-.constant {
-  color: @orange;
-
-  &.character.escape {
-    color: @cyan;
-  }
-
-  &.numeric {
-    color: @orange;
-  }
-
-  &.other.color {
-    color: @cyan;
-  }
-
-  &.other.symbol {
-    color: @green;
-  }
-}
-
-.variable {
-  color: @red;
-
-  &.interpolation {
-    color: darken(@red, 10%);
-  }
-
-  &.parameter.function {
-    color: @syntax-text-color;
-  }
-}
-
-.invalid.illegal {
-  background-color: @red;
-  color: @syntax-background-color;
-}
-
-.string {
-  color: @green;
-
-
-  &.regexp {
-    color: @cyan;
-
-    .source.ruby.embedded {
+    &.other.unit {
       color: @orange;
     }
   }
 
-  &.other.link {
-    color: @red;
+  .storage {
+    color: @purple;
   }
-}
 
-.punctuation {
-  &.definition {
-    &.comment {
-      color: @light-gray;
+  .constant {
+    color: @orange;
+
+    &.character.escape {
+      color: @cyan;
     }
 
-    &.string,
-    &.variable,
-    &.parameters,
-    &.array {
+    &.numeric {
+      color: @orange;
+    }
+
+    &.other.color {
+      color: @cyan;
+    }
+
+    &.other.symbol {
+      color: @green;
+    }
+  }
+
+  .variable {
+    color: @red;
+
+    &.interpolation {
+      color: darken(@red, 10%);
+    }
+
+    &.parameter.function {
       color: @syntax-text-color;
     }
+  }
 
-    &.heading,
-    &.identity {
+  .invalid.illegal {
+    background-color: @red;
+    color: @syntax-background-color;
+  }
+
+  .string {
+    color: @green;
+
+
+    &.regexp {
+      color: @cyan;
+
+      .source.ruby.embedded {
+        color: @orange;
+      }
+    }
+
+    &.other.link {
+      color: @red;
+    }
+  }
+
+  .punctuation {
+    &.definition {
+      &.comment {
+        color: @light-gray;
+      }
+
+      &.string,
+      &.variable,
+      &.parameters,
+      &.array {
+        color: @syntax-text-color;
+      }
+
+      &.heading,
+      &.identity {
+        color: @blue;
+      }
+
+      &.bold {
+        color: @light-orange;
+        font-style: bold;
+      }
+
+      &.italic {
+        color: @purple;
+        font-style: italic;
+      }
+    }
+
+    &.section.embedded {
+      color: darken(@red, 10%);
+    }
+
+  }
+
+  .support {
+    &.class {
+      color: @light-orange;
+    }
+
+    &.function  {
+      color: @cyan;
+
+      &.any-method {
+        color: @blue;
+      }
+    }
+  }
+
+  .entity {
+    &.name.function {
       color: @blue;
     }
 
-    &.bold {
+    &.name.class, &.name.type.class {
       color: @light-orange;
+    }
+
+    &.name.section {
+      color: @blue;
+    }
+
+    &.name.tag {
+      color: @red;
+      text-decoration: underline;
+    }
+
+    &.other.attribute-name {
+      color: @orange;
+
+      &.id {
+        color: @blue;
+      }
+    }
+  }
+
+  .meta {
+    &.class {
+      color: @light-orange;
+    }
+
+    &.link {
+      color: @orange;
+    }
+
+    &.require {
+      color: @blue;
+    }
+
+    &.selector {
+      color: @purple;
+    }
+
+    &.separator {
+      background-color: @gray;
+      color: @syntax-text-color;
+    }
+  }
+
+  .none {
+    color: @syntax-text-color;
+  }
+
+  .markup {
+    &.bold {
+      color: @orange;
       font-style: bold;
+    }
+
+    &.changed {
+      color: @purple;
+    }
+
+    &.deleted {
+      color: @red;
     }
 
     &.italic {
       color: @purple;
       font-style: italic;
     }
-  }
 
-  &.section.embedded {
-    color: darken(@red, 10%);
-  }
-
-}
-
-.support {
-  &.class {
-    color: @light-orange;
-  }
-
-  &.function  {
-    color: @cyan;
-
-    &.any-method {
+    &.heading .punctuation.definition.heading {
       color: @blue;
+    }
+
+    &.inserted {
+      color: @green;
+    }
+
+    &.list {
+      color: @red;
+    }
+
+    &.quote {
+      color: @orange;
+    }
+
+    &.raw.inline {
+      color: @green;
+    }
+  }
+
+  .source.gfm .markup {
+    -webkit-font-smoothing: auto;
+    &.heading {
+      color: @green;
     }
   }
 }
 
-.entity {
-  &.name.function {
-    color: @blue;
-  }
-
-  &.name.class, &.name.type.class {
-    color: @light-orange;
-  }
-
-  &.name.section {
-    color: @blue;
-  }
-
-  &.name.tag {
-    color: @red;
-    text-decoration: underline;
-  }
-
-  &.other.attribute-name {
-    color: @orange;
-
-    &.id {
-      color: @blue;
-    }
-  }
+.editor .search-results .marker .region, :host .search-results .marker .region {
+  background-color: transparent;
+  border: 1px solid @syntax-result-marker-color;
 }
 
-.meta {
-  &.class {
-    color: @light-orange;
-  }
-
-  &.link {
-    color: @orange;
-  }
-
-  &.require {
-    color: @blue;
-  }
-
-  &.selector {
-    color: @purple;
-  }
-
-  &.separator {
-    background-color: @gray;
-    color: @syntax-text-color;
-  }
+.editor .search-results .marker.current-result .region, :host .search-results .marker.current-result .region {
+  border: 1px solid @syntax-result-marker-color-selected;
 }
 
-.none {
-  color: @syntax-text-color;
-}
 
-.markup {
-  &.bold {
-    color: @orange;
-    font-style: bold;
-  }
-
-  &.changed {
-    color: @purple;
-  }
-
-  &.deleted {
-    color: @red;
-  }
-
-  &.italic {
-    color: @purple;
-    font-style: italic;
-  }
-
-  &.heading .punctuation.definition.heading {
-    color: @blue;
-  }
-
-  &.inserted {
-    color: @green;
-  }
-
-  &.list {
-    color: @red;
-  }
-
-  &.quote {
-    color: @orange;
-  }
-
-  &.raw.inline {
-    color: @green;
-  }
-}
-
-.source.gfm .markup {
-  -webkit-font-smoothing: auto;
-  &.heading {
-    color: @green;
-  }
-}
-
-.editor.mini .scroll-view {
+.editor.mini .scroll-view, :host(.mini) .scroll-view{
   padding-left: 1px;
 }


### PR DESCRIPTION
This commit includes shadow-dom-aware patterns as optional alternatives to the `.editor` selector based ones in line with the upgrade guide! This brings toro syntax forward along with Atom's new shadow dom requirements. Ultimately, this silences some warnings that atom emits and eliminates some dynamic rewrites that atom makes on startup.
